### PR TITLE
Change to target Framework 3.5 (what KSP uses)

### DIFF
--- a/Source/AJE.csproj
+++ b/Source/AJE.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <ProjectGuid>{3E558682-68D1-4DE5-9C7E-797CCE771B68}</ProjectGuid>
   </PropertyGroup>


### PR DESCRIPTION
There are a variety of reasons why KSP assemblies should target 3.5; quite apart from things breaking if you use a feature from a framework KSP doesn't support, it also makes referencing hard.
