### PR TITLE
sound effect change with throttle

### DIFF
--- a/Source/EngineWrapper.cs
+++ b/Source/EngineWrapper.cs
@@ -87,7 +87,8 @@ namespace AJE
             {
                 this.maxThrust = 0.0001f;
             }
-            this.minThrust = this.maxThrust * idle;
+            this.finalThrust = this.maxThrust * idle;
+            this.maxThrust = this.maxThrust / this.currentThrottle;
         }
 
         public float maxThrust
@@ -135,6 +136,24 @@ namespace AJE
                         break;
                     case EngineType.ModuleEngineFX:
                         engineFX.minThrust = value;
+                        break;
+                    case EngineType.FSengine:
+                        break;
+                }
+            }
+        }
+
+        public float finalThrust
+        {
+            set
+            {
+                switch (type)
+                {
+                    case EngineType.ModuleEngine:
+                        engine.finalThrust = value;
+                        break;
+                    case EngineType.ModuleEngineFX:
+                        engineFX.finalThrust = value;
                         break;
                     case EngineType.FSengine:
                         break;


### PR DESCRIPTION
In **SetThrust()**, do not set **minThrust** to **maxThrust**.

Set **finalThrust** to **maxThrust**,
then set **maxThrust** to (**maxThrust** / **currentThrottle**).

This time thrust should be correct.
**maxThrust** is still wrong,
but it's better than making the sound staying at max volume.

I tested **JetEngine**, **B9_Engine_SABRE_S** and **B9_Engine_Jet_Pod_Small**.
In the picture,
the left engine use new way to set thrust (finalThrust = maxThrust, maxThrust = maxThrust / currentThrottle),
the right engine use the old way (minThrust = maxThrust).
The plane can go straight forward.
![screenshot15](https://cloud.githubusercontent.com/assets/7445439/6439677/f8384e2e-c10f-11e4-976f-96624160f98b.png)

Here is my test files: https://github.com/bssthu/AJE/releases/tag/2.0.3 (Sorry I don't have a net disk)

(Hope this commit didn't mess up something...)
