### PR TITLE
Tweak the wildcards

### DIFF
--- a/GameData/AJE/zFinal/zzWildcards.cfg
+++ b/GameData/AJE/zFinal/zzWildcards.cfg
@@ -92,7 +92,7 @@
 }
 
 
-@PART[*]:HAS[@MODULE[AJEModule]]:NEEDS[RealFuels]:Final
+@PART[*]:HAS[@MODULE[AJEModule],~RSSROConfig[]]:NEEDS[RealFuels]:Final
 {
 
 	@MODULE[ModuleEngines*]
@@ -105,24 +105,20 @@
 
 }
 
-@PART[*]:HAS[@MODULE[AJEPropeller]]:NEEDS[RealFuels]:Final
+@PART[*]:HAS[@MODULE[AJEPropeller],~RSSROConfig[]]:NEEDS[RealFuels]:Final
 {
 
 	@MODULE[ModuleEngines*]
 	{
 		@PROPELLANT[LiquidFuel]
 		{
-			@name=Kerosene
-		}
-		@PROPELLANT[AvGas]
-		{
-			@name=Kerosene
+			@name=AvGas // Piston engines run on AvGas
 		}
 	}
 
 }
 
-@PART[*]:HAS[@MODULE[AJERotor]]:NEEDS[RealFuels]:Final
+@PART[*]:HAS[@MODULE[AJERotor],~RSSROConfig[]]:NEEDS[RealFuels]:Final
 {
 
 	@MODULE[ModuleEngines*]
@@ -157,6 +153,10 @@
 			@name = LiquidFuel
 		}
 		@PROPELLANT[Kerosene]
+		{
+			@name = LiquidFuel
+		}
+		@PROPELLANT[AvGas]
 		{
 			@name = LiquidFuel
 		}


### PR DESCRIPTION
- Ignore RF fuel patches if parts are already configured by RO
- Set props to use AvGas (should set by hand any turboprops that should use kerosene instead?)
- Added catcher to reset AvGas if no RF present.
