### PR TITLE
Why copypasta when MM can do it for you?

### DIFF
--- a/GameData/AJE/Inlets/Squad.cfg
+++ b/GameData/AJE/Inlets/Squad.cfg
@@ -1,188 +1,95 @@
 @PART[shockConeIntake]:FOR[AJE]
 {
-	@mass=0.4
-	@description= Fixed cone inlet, optimized for supersonic speed
+	@mass = 0.4
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/FixedCone/description$
 	@MODULE[ModuleResourceIntake]
 	{
 		@name=AJEInlet
-		Area=0.675
-		TPRCurve
-		{
-			key = 0.0	0.85	0	0
-			key = 1.0	0.90	0	0
-			key = 1.5	0.95	0	0
-			key = 2.0	0.95	0	0			
-			key = 2.5	0.90	0	0
-			key = 3.0	0.80	0	0
-			key = 4.0	0.65	0	0
-			key = 8.0	0.00	0	0
-		}
+		Area = 0.675
+		#@AJE_TPR_CURVE_DEFAULTS/FixedCone/TPRCurve {}
 	}
 }
 
 @PART[IntakeRadialLong]:FOR[AJE]
 {
-	@mass=0.1
-	@description= Adjustable inlet, optimized for supersonic speed
+	@mass = 0.1
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/description$
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.085
-		TPRCurve
-		{
-			key = 0.0	0.85	0	0
-			key = 1.0	0.96	0	0
-			key = 2.0	0.95	0	0			
-			key = 2.5	0.90	0	0
-			key = 3.0	0.80	0	0
-			key = 4.0	0.65	0	0
-			key = 8.0	0.00	0	0
-		}
+		@name = AJEInlet
+		Area = 0.085
+		#@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/TPRCurve {}
 	}
 }
 
 @PART[CircularIntake]:FOR[AJE]
 {
-	@description=Pitot tube inlet, designed for subsonic flight
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/PilotTube/description$
 	
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.6375
-		TPRCurve
-		{
-			key = 0.0	0.95	0	0
-			key = 1.0	0.97	0	0
-			key = 1.5	0.90	0	0			
-			key = 1.8	0.80	0	0
-			key = 2.0	0.70	0	0
-			key = 2.5	0.45	0	0
-			key = 3.5	0.00	0	0
-		}
+		@name = AJEInlet
+		Area = 0.6375
+		#@AJE_TPR_CURVE_DEFAULTS/PilotTube/TPRCurve {}
 	}
 }
 
 @PART[CircularIntakeSmall]:FOR[AJE]
 {
-	@description=Pitot tube inlet, designed for subsonic flight
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/PilotTube/description$
 	
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.16
-		TPRCurve
-		{
-			key = 0.0	0.95	0	0
-			key = 1.0	0.97	0	0
-			key = 1.5	0.90	0	0			
-			key = 1.8	0.80	0	0
-			key = 2.0	0.70	0	0
-			key = 2.5	0.45	0	0
-			key = 3.5	0.00	0	0
-		}
-	}
-}
-
-@PART[CircularIntakesmall]:FOR[AJE]
-{
-	@description=Pitot tube inlet, designed for subsonic flight
-	
-	@MODULE[ModuleResourceIntake]
-	{
-		@name=AJEInlet
-		Area=0.16
-		TPRCurve
-		{
-			key = 0.0	0.95	0	0
-			key = 1.0	0.97	0	0
-			key = 1.5	0.90	0	0			
-			key = 1.8	0.80	0	0
-			key = 2.0	0.70	0	0
-			key = 2.5	0.45	0	0
-			key = 3.5	0.00	0	0
-		}
+		@name = AJEInlet
+		Area = 0.16
+		#@AJE_TPR_CURVE_DEFAULTS/PilotTube/TPRCurve {}
 	}
 }
 
 @PART[ramAirIntake]:FOR[AJE]
 {
-	@description= Adjustable inlet, optimized for supersonic speed
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/description$
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.75
-		TPRCurve
-		{
-			key = 0.0	0.85	0	0
-			key = 1.0	0.96	0	0
-			key = 2.0	0.95	0	0			
-			key = 2.5	0.90	0	0
-			key = 3.0	0.80	0	0
-			key = 4.0	0.65	0	0
-			key = 8.0	0.00	0	0
-		}
+		@name = AJEInlet
+		Area = 0.75
+		#@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/TPRCurve {}
 	}
 }
 
 @PART[ramAirIntakeSmall]:FOR[AJE]
 {
-	@description= Adjustable inlet, optimized for supersonic speed
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/description$
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.1875
+		@name = AJEInlet
+		Area = 0.1875
 		TPRCurve
-		{
-			key = 0.0	0.85	0	0
-			key = 1.0	0.96	0	0
-			key = 2.0	0.95	0	0			
-			key = 2.5	0.90	0	0
-			key = 3.0	0.80	0	0
-			key = 4.0	0.65	0	0
-			key = 8.0	0.00	0	0
-		}
+		#@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/TPRCurve {}
 	}
 }
 
 @PART[airScoop]:FOR[AJE]
 {
-	@description=Pitot tube inlet, designed for subsonic flight
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/PilotTube/description$
 	
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.2
-		TPRCurve
-		{
-			key = 0.0	0.95	0	0
-			key = 1.0	0.97	0	0
-			key = 1.5	0.90	0	0			
-			key = 1.8	0.80	0	0
-			key = 2.0	0.70	0	0
-			key = 2.5	0.45	0	0
-			key = 3.5	0.00	0	0
-		}
+		@name = AJEInlet
+		Area = 0.2
+		#@AJE_TPR_CURVE_DEFAULTS/PilotTube/TPRCurve {}
 	}
 }
 
 @PART[airScoopSmall]:FOR[AJE]
 {
-	@description=Pitot tube inlet, designed for subsonic flight
+	@description = #$@AJE_TPR_CURVE_DEFAULTS/PilotTube/description$
 	
 	@MODULE[ModuleResourceIntake]
 	{
-		@name=AJEInlet
-		Area=0.05
-		TPRCurve
-		{
-			key = 0.0	0.95	0	0
-			key = 1.0	0.97	0	0
-			key = 1.5	0.90	0	0			
-			key = 1.8	0.80	0	0
-			key = 2.0	0.70	0	0
-			key = 2.5	0.45	0	0
-			key = 3.5	0.00	0	0
-		}
+		@name = AJEInlet
+		Area = 0.05
+		#@AJE_TPR_CURVE_DEFAULTS/PilotTube/TPRCurve {}
 	}
 }
 

--- a/GameData/AJE/Inlets/TPRCurveDefaults.cfg
+++ b/GameData/AJE/Inlets/TPRCurveDefaults.cfg
@@ -1,0 +1,63 @@
+AJE_TPR_CURVE_DEFAULTS
+{
+	PilotTube
+	{
+		description = Pilot tube inlet, designed for subsonic flight
+		TPRCurve
+		{
+			key = 0.0	0.95	0	0
+			key = 1.0	0.97	0	0
+			key = 1.5	0.90	0	0			
+			key = 1.8	0.80	0	0
+			key = 2.0	0.70	0	0
+			key = 2.5	0.45	0	0
+			key = 3.5	0.00	0	0
+		}
+	}
+	
+	DSI
+	{
+		description = DSI inlet, optimized for transonic speed
+		TPRCurve
+		{
+			key = 0.0	0.90	0	0
+			key = 1.0	0.97	0	0
+			key = 1.5	0.95	0	0			
+			key = 1.8	0.90	0	0
+			key = 2.0	0.85	0	0
+			key = 3.0	0.60	0	0
+			key = 5.0	0.00	0	0
+		}
+	}
+	
+	AdjustableSupersonic
+	{
+		description = Adjustable inlet, optimized for supersonic speed
+		TPRCurve
+		{
+			key = 0.0	0.85	0	0
+			key = 1.0	0.96	0	0
+			key = 2.0	0.95	0	0			
+			key = 2.5	0.90	0	0
+			key = 3.0	0.80	0	0
+			key = 4.0	0.65	0	0
+			key = 8.0	0.00	0	0
+		}
+	}
+	
+	FixedCone
+	{
+		description = Fixed cone inlet, optimized for supersonic speed
+		TPRCurve
+		{
+			key = 0.0	0.85	0	0
+			key = 1.0	0.90	0	0
+			key = 1.5	0.95	0	0
+			key = 2.0	0.95	0	0			
+			key = 2.5	0.90	0	0
+			key = 3.0	0.80	0	0
+			key = 4.0	0.65	0	0
+			key = 8.0	0.00	0	0
+		}
+	}
+}


### PR DESCRIPTION
Inlet TPR curves can be defined separately and referenced using MM.
Cleans up the intake definitions a bit and makes it simpler to adjust
TPR curves.
